### PR TITLE
Angular CLI AOT Fix

### DIFF
--- a/src/signalr.module.ts
+++ b/src/signalr.module.ts
@@ -31,13 +31,13 @@ function getJquery(): any {
                 }]
 })
 export class SignalRModule {
-    public static configure(configuration: SignalRConfiguration): ModuleWithProviders {
+    public static forRoot(getSignalRConfiguration: Function): ModuleWithProviders {
         return {
             ngModule: SignalRModule,
             providers: [
                 {
                     provide: SIGNALR_CONFIGURATION,
-                    useValue: configuration
+                    useFactory: getSignalRConfiguration
                 },
                 {
                     provide: SignalR,

--- a/src/signalr.ts
+++ b/src/signalr.ts
@@ -12,7 +12,7 @@ export class SignalR {
     private _zone: NgZone;
     private _jHubConnectionFn: any;
 
-    public constructor(configuration: SignalRConfiguration, zone: NgZone, jHubConnectionFn: (url: string) => any) {
+    public constructor(configuration: SignalRConfiguration, zone: NgZone, jHubConnectionFn: Function) {
         this._configuration = configuration;
         this._zone = zone;
         this._jHubConnectionFn = jHubConnectionFn;


### PR DESCRIPTION
This code fix aims to solve the problems in #14. It involves passing a function instead of a config class in the module root function call, and replacing a lamda expression with a more generic typing in the signalr.ts file.

The library builds with both the runtime and AOT compiler. I have successfully packaged, installed, and confirmed that the changes work with an AOT build in an Angular CLI application.

**Note**: The README will need to be updated, and a new minor version would be ideal since this is a breaking change (version 1.1.0). Please refer to my posts on #14 for usage details.