### PR TITLE
Broken SignalR dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@angular/core": ">= 2.0.0 || >= 4.0.0",
         "@angular/router": ">=3.0.0 || >= 4.0.0",
         "jquery": ">=2.0.0",
-        "signalr": "^>=2.2.1"
+        "signalr": ">=2.2.1"
     },
     "devDependencies": {
         "@angular/common": "2.4.6",


### PR DESCRIPTION
I think you put a carat here where there isn't meant to be one. Running npm install with it tells us that signalr is then an unmet dependency.