### PR TITLE
Allow responses with multiple fields

### DIFF
--- a/src/services/connection/signalr.connection.ts
+++ b/src/services/connection/signalr.connection.ts
@@ -100,7 +100,7 @@ export class SignalRConnection implements ISignalRConnection {
             this.run(() => {
                 let casted: T = null;
                 if (args.length > 0) {
-                    casted = <T> args[0];
+                    casted = <T> args;
                 }
                 this.log('SignalRConnection.proxy.on invoked. Calling listener next() ...');
                 listener.next(casted);


### PR DESCRIPTION
I had a signalR server that responded with 2 fields (name and data), but before this change I could only read the name which discarded the important part (the data).