### PR TITLE
Added stricker rules to tslint and now all logging follow configurations

### DIFF
--- a/projects/ng2-signalr/src/lib/services/connection/signalr.connection.ts
+++ b/projects/ng2-signalr/src/lib/services/connection/signalr.connection.ts
@@ -48,12 +48,12 @@ export class SignalRConnection implements ISignalRConnection {
                     withCredentials: this._configuration.withCredentials,
                 })
                 .done(() => {
-                    console.log('Connection established, ID: ' + this._jConnection.id);
-                    console.log('Connection established, Transport: ' + this._jConnection.transport.name);
+                    this.log('Connection established, ID: ' + this._jConnection.id);
+                    this.log('Connection established, Transport: ' + this._jConnection.transport.name);
                     resolve(this);
                 })
                 .fail((error: any) => {
-                    console.log('Could not connect');
+                    this.log('Could not connect');
                     reject('Failed to connect. Error: ' + error.message); // ex: Error during negotiation request.
                 });
         });
@@ -82,9 +82,9 @@ export class SignalRConnection implements ISignalRConnection {
                     this.log(`Promise resolved.`);
                 })
                 .fail((err: any) => {
-                    console.log(`Invoking \'${method}\' failed. Rejecting promise...`);
+                    this.log(`Invoking \'${method}\' failed. Rejecting promise...`);
                     reject(err);
-                    console.log(`Promise rejected.`);
+                    this.log(`Promise rejected.`);
                 });
         });
         return $promise;
@@ -219,6 +219,7 @@ export class SignalRConnection implements ISignalRConnection {
         if (this._jConnection.logging === false) {
             return;
         }
+        // tslint:disable-next-line: no-console
         console.log(args.join(', '));
     }
 

--- a/projects/ng2-signalr/src/lib/services/signalr.ts
+++ b/projects/ng2-signalr/src/lib/services/signalr.ts
@@ -52,13 +52,18 @@ export class SignalR {
             const serializedQs = JSON.stringify(configuration.qs);
             const serializedTransport = JSON.stringify(configuration.transport);
             if (configuration.logging) {
-                console.log(`Creating connecting with...`);
-                console.log(`configuration:[url: '${configuration.url}'] ...`);
-                console.log(`configuration:[hubName: '${configuration.hubName}'] ...`);
-                console.log(`configuration:[qs: '${serializedQs}'] ...`);
-                console.log(`configuration:[transport: '${serializedTransport}'] ...`);
+                this.log(`Creating connecting with...`);
+                this.log(`configuration:[url: '${configuration.url}'] ...`);
+                this.log(`configuration:[hubName: '${configuration.hubName}'] ...`);
+                this.log(`configuration:[qs: '${serializedQs}'] ...`);
+                this.log(`configuration:[transport: '${serializedTransport}'] ...`);
             }
         } catch (err) { /* */ }
+    }
+
+    private log(str: string) {
+      // tslint:disable-next-line: no-console
+      console.log(str);
     }
 
     private merge(overrides: IConnectionOptions): SignalRConfiguration {

--- a/tslint.json
+++ b/tslint.json
@@ -43,14 +43,7 @@
       }
     ],
     "no-consecutive-blank-lines": false,
-    "no-console": [
-      true,
-      "debug",
-      "info",
-      "time",
-      "timeEnd",
-      "trace"
-    ],
+    "no-console": true,
     "no-empty": false,
     "no-inferrable-types": [
       true,


### PR DESCRIPTION
Now all loggings follow the configuration rule. Added sticker rule on ts-lint and added a tslint:disable-next-line on console logs